### PR TITLE
Add flag to censor long display names

### DIFF
--- a/src/main/java/reposense/RepoSense.java
+++ b/src/main/java/reposense/RepoSense.java
@@ -10,6 +10,7 @@ import java.util.logging.Logger;
 
 import net.sourceforge.argparse4j.helper.HelpScreenException;
 import reposense.git.GitConfig;
+import reposense.model.AuthorConfiguration;
 import reposense.model.BlurbMap;
 import reposense.model.CliArguments;
 import reposense.model.RepoConfiguration;
@@ -69,6 +70,9 @@ public class RepoSense {
                     cliArguments.isShallowCloningPerformed());
             RepoConfiguration.setIsFindingPreviousAuthorsPerformedToRepoConfigs(configs,
                     cliArguments.isFindingPreviousAuthorsPerformed());
+
+            AuthorConfiguration.setNameCensor(cliArguments.isNameCensored(),
+                    cliArguments.getNameCensorFront(), cliArguments.getNameCensorBack());
 
             List<String[]> globalGitConfig = GitConfig.getGlobalGitLfsConfig();
             if (globalGitConfig.size() != 0) {

--- a/src/main/java/reposense/model/CliArguments.java
+++ b/src/main/java/reposense/model/CliArguments.java
@@ -39,6 +39,9 @@ public class CliArguments {
     private double originalityThreshold;
     private boolean isTestMode = ArgsParser.DEFAULT_IS_TEST_MODE;
     private boolean isFreshClonePerformed = ArgsParser.DEFAULT_SHOULD_FRESH_CLONE;
+    private boolean isNameCensored;
+    private int nameCensorFront;
+    private int nameCensorBack;
 
     private List<String> locations;
     private boolean isViewModeOnly;
@@ -178,6 +181,18 @@ public class CliArguments {
         return originalityThreshold;
     }
 
+    public boolean isNameCensored() {
+        return isNameCensored;
+    }
+
+    public int getNameCensorFront() {
+        return nameCensorFront;
+    }
+
+    public int getNameCensorBack() {
+        return nameCensorBack;
+    }
+
     @Override
     public boolean equals(Object other) {
         // short circuit if same object
@@ -218,6 +233,9 @@ public class CliArguments {
                 && Objects.equals(this.reportConfigFilePath, otherCliArguments.reportConfigFilePath)
                 && Objects.equals(this.blurbMap, otherCliArguments.blurbMap)
                 && this.isAuthorshipAnalyzed == otherCliArguments.isAuthorshipAnalyzed
+                && this.isNameCensored == otherCliArguments.isNameCensored
+                && this.nameCensorFront == otherCliArguments.nameCensorFront
+                && this.nameCensorBack == otherCliArguments.nameCensorBack
                 && Objects.equals(this.originalityThreshold, otherCliArguments.originalityThreshold);
     }
 
@@ -500,6 +518,36 @@ public class CliArguments {
          */
         public Builder blurbMap(BlurbMap blurbMap) {
             this.cliArguments.blurbMap = blurbMap;
+            return this;
+        }
+
+        /**
+         * Adds the {@code isNameCensored} to CliArguments.
+         *
+         * @param isNameCensored Is name censored.
+         */
+        public Builder isNameCensored(boolean isNameCensored) {
+            this.cliArguments.isNameCensored = isNameCensored;
+            return this;
+        }
+
+        /**
+         * Adds the {@code nameCensorFront} to CliArguments.
+         *
+         * @param nameCensorFront The number of characters at the start not censored.
+         */
+        public Builder nameCensorFront(int nameCensorFront) {
+            this.cliArguments.nameCensorFront = nameCensorFront;
+            return this;
+        }
+
+        /**
+         * Adds the {@code nameCensorBack} to CliArguments.
+         *
+         * @param nameCensorBack The number of characters at the end not censored.
+         */
+        public Builder nameCensorBack(int nameCensorBack) {
+            this.cliArguments.nameCensorBack = nameCensorBack;
             return this;
         }
 

--- a/src/main/java/reposense/parser/ArgsParser.java
+++ b/src/main/java/reposense/parser/ArgsParser.java
@@ -79,6 +79,7 @@ public class ArgsParser {
     public static final String[] FRESH_CLONING_FLAG = new String[] {"--fresh-cloning"};
     public static final String[] ANALYZE_AUTHORSHIP_FLAGS = new String[] {"--analyze-authorship", "-A"};
     public static final String[] ORIGINALITY_THRESHOLD_FLAGS = new String[] {"--originality-threshold", "-ot"};
+    public static final String[] NAME_CENSOR_FLAGS = new String[] {"--censor-name", "-C"};
 
     private static final Logger logger = LogsManager.getLogger(ArgsParser.class);
 
@@ -233,6 +234,12 @@ public class ArgsParser {
                         + "is performed. Author will be given full credit if their contribution exceeds this "
                         + "threshold, else partial credit is given.");
 
+        parser.addArgument(NAME_CENSOR_FLAGS)
+                .dest(NAME_CENSOR_FLAGS[0])
+                .nargs(2)
+                .help("Censors the names in the report except the first x and the last y characters, "
+                        + "where and y are the first and second arguments respectively.");
+
         // Mutex flags - these will always be the last parameters in help message.
         mutexParser.addArgument(CONFIG_FLAGS)
                 .dest(CONFIG_FLAGS[0])
@@ -320,8 +327,23 @@ public class ArgsParser {
         boolean isTestMode = results.get(TEST_MODE_FLAG[0]);
         boolean isAuthorshipAnalyzed = results.get(ANALYZE_AUTHORSHIP_FLAGS[0]);
         double originalityThreshold = results.get(ORIGINALITY_THRESHOLD_FLAGS[0]);
+        List<String> nameCensor = results.get(NAME_CENSOR_FLAGS[0]);
         int numCloningThreads = results.get(CLONING_THREADS_FLAG[0]);
         int numAnalysisThreads = results.get(ANALYSIS_THREADS_FLAG[0]);
+
+        boolean isNameCensored = nameCensor != null;
+        int nameCensorFront = 0;
+        int nameCensorBack = 0;
+
+        if (isNameCensored) {
+                try {
+                        nameCensorFront = Math.max(0, Integer.valueOf(nameCensor.get(0)));
+                        nameCensorBack = Math.max(0, Integer.valueOf(nameCensor.get(1)));
+                } catch (NumberFormatException e) {
+                        nameCensorFront = 0;
+                        nameCensorBack = 0;
+                }
+        }
 
         CliArguments.Builder cliArgumentsBuilder = new CliArguments.Builder()
                 .configFolderPath(configFolderPath)
@@ -339,6 +361,9 @@ public class ArgsParser {
                 .numCloningThreads(numCloningThreads)
                 .numAnalysisThreads(numAnalysisThreads)
                 .isTestMode(isTestMode)
+                .isNameCensored(isNameCensored)
+                .nameCensorFront(nameCensorFront)
+                .nameCensorBack(nameCensorBack)
                 .isAuthorshipAnalyzed(isAuthorshipAnalyzed)
                 .originalityThreshold(originalityThreshold);
 


### PR DESCRIPTION
### Proposed commit message

Add flag to truncate long display names

### Other information

Use the flag `--censor-name` or `-C` to use this feature. It takes in 2 parameters, which represent the number of characters shown at the front and at the end of a name respectively. The rest of the name will be truncated. Truncated portions are replaced with `..`.

Command (without truncation): `./gradlew run -Dargs="--repos https://github.com/reposense/RepoSense.git --output ./report_folder --since 31/1/2017 --formats java adoc xml --view --ignore-standalone-config --last-modified-date --timezone UTC+08 --find-previous-authors"`

![Without](https://github.com/jedkohjk/RepoSense/assets/110604064/f98eaee6-bdb2-45d7-aee0-f86f4629db6d)

Command (with truncation): `./gradlew run -Dargs="--repos https://github.com/reposense/RepoSense.git --output ./report_folder --since 31/1/2017 --formats java adoc xml --view --ignore-standalone-config --last-modified-date --timezone UTC+08 --find-previous-authors --censor-name 4 3"`

![With](https://github.com/jedkohjk/RepoSense/assets/110604064/0bb91297-c681-4368-b888-9f1d12b6dd5e)
